### PR TITLE
adds ABS Indicator on Brake Trace

### DIFF
--- a/telemetry_overlay/_telemetry_overlay/app.py
+++ b/telemetry_overlay/_telemetry_overlay/app.py
@@ -169,6 +169,8 @@ class App:
             self.telemetry.update_telemetry()
 
             self.pedals.update()
+            brake_color = self.config.brake_abs_color if self.telemetry.abs_active else self.config.brake_color
+            self.telemetry.abs_active = False
 
             if self.IS_CSP:
                 values = []
@@ -192,6 +194,8 @@ class App:
                 self.csp_graph.add_values(values)
             else:
                 if self.ac_graph_traces['brake']:
+                    if self.ac_graph_traces['brake'].color != brake_color:
+                        self.ac_graph_traces['brake'].update_color(brake_color)
                     self.ac_graph_traces['brake'].add_value(self.telemetry.brake)
                 if self.ac_graph_traces['throttle']:
                     self.ac_graph_traces['throttle'].add_value(self.telemetry.throttle)

--- a/telemetry_overlay/_telemetry_overlay/config.py
+++ b/telemetry_overlay/_telemetry_overlay/config.py
@@ -52,6 +52,7 @@ class Config:
         self.wheel_angle=15 # Width of the wheel
         self.throttle_color=(0.16, 1.0, 0.0, 1.0)    # Color of the throttle trace
         self.brake_color=(1.0, 0.16, 0.0, 1.0)   # Color of the brake trace
+        self.brake_abs_color=(1.0, 1.0, 0.0, 1.0)   # Color of the brake trace when ABS is triggered (yellow)
         self.clutch_color=(0.16, 1.0, 1.0, 1.0)  # Color of the clutch trace
         self.steering_color=(0.9, 0.9, 0.9, 1.0)  # Color of the steering trace
         self.handbrake_color=(0.0, 0.16, 1.0, 1.0)   # Color of the handbrake trace

--- a/telemetry_overlay/_telemetry_overlay/data.py
+++ b/telemetry_overlay/_telemetry_overlay/data.py
@@ -31,6 +31,7 @@ class TelemetryData:
     steering = 0
     steering_norm = 0.5
     ffb = 0
+    abs_active = False
     gx_values = []
     gz_values = []
     max_x = 2.8
@@ -56,6 +57,13 @@ class TelemetryData:
         self.brake = ac.getCarState(self.car_id, acsys.CS.Brake)
         self.clutch = 1 - ac.getCarState(self.car_id, acsys.CS.Clutch)
         self.ffb = ac.getCarState(self.car_id, acsys.CS.LastFF)
+        if self.IS_CSP:
+            try:
+                if ac.ext_getStateAbsActive(self.car_id):
+                    self.abs_active = True
+            except:
+                pass
+        
         self.steering = ac.getCarState(self.car_id, acsys.CS.Steer)
         self.steering_norm = min(
             max(


### PR DESCRIPTION
Did a quick and dirty implementation of ABS Indicator on Brake Trace with sticky state, so if the abs enables and disables before a single pixel would have been rendered we see it 
Fixes #7 

<img width="331" height="186" alt="image" src="https://github.com/user-attachments/assets/f81f445d-8f93-407d-be53-b2843c434902" />

